### PR TITLE
Round time

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Version (next)
 --------------
 
 * The `/stats` page now has shows symbols to indicate recent page retrieval activity, to help gauge how active a given item currently is.
+* End times and reloan times are now rounded to whole minutes. This is to help avoid confusing situations where loans seem to go past their allotted times.
 
 
 Version 0.1.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Change log for DIBS
 ===================
 
+Version (next)
+--------------
+
+* The `/stats` page now has shows symbols to indicate recent page retrieval activity, to help gauge how active a given item currently is.
+
+
 Version 0.1.1
 --------------
 

--- a/dibs/date_utils.py
+++ b/dibs/date_utils.py
@@ -10,6 +10,8 @@ file "LICENSE" for more information.
 '''
 
 import arrow
+import datetime
+from   datetime import timedelta
 
 
 # Exported functions.
@@ -22,3 +24,10 @@ def human_datetime(value, format = "%I:%M %p (%Z) on %Y-%m-%d"):
     time = arrow.get(value).to('local').strftime(format)
     # Stftime has no option to *not* zero-pad the numbers, so we have to do it:
     return time.lstrip('0')
+
+
+def round_minutes(time, direction):
+    '''Round the given time to the minute according in the desired direction.'''
+    new_minute = (time.minute + (1 if direction == 'up' else 0))
+    new_time = time + datetime.timedelta(minutes = new_minute - time.minute)
+    return new_time.replace(second = 0, microsecond = 0)

--- a/dibs/server.py
+++ b/dibs/server.py
@@ -61,10 +61,8 @@ _MANIFEST_DIR = config('MANIFEST_DIR', default = 'manifests')
 _IIIF_BASE_URL = config('IIIF_BASE_URL')
 
 # Cooling-off period after a loan ends, before user can borrow same title again.
-# _RELOAN_WAIT_TIME = (delta(minutes = 1) if getattr(dibs, 'debug_mode', False)
-#                      else delta(minutes = int(config('RELOAN_WAIT_TIME', default = 30))))
-
-_RELOAN_WAIT_TIME = delta(minutes = 1)
+_RELOAN_WAIT_TIME = (delta(minutes = 1) if getattr(dibs, 'debug_mode', False)
+                     else delta(minutes = int(config('RELOAN_WAIT_TIME', default = 30))))
 
 # Where we send users to give feedback.
 _FEEDBACK_URL = config('FEEDBACK_URL', default = '/')

--- a/dibs/templates/common/bar.tpl
+++ b/dibs/templates/common/bar.tpl
@@ -1,0 +1,14 @@
+<!-- For character codes see https://en.wikipedia.org/wiki/Block_Elements -->
+%if get('value', 0) == 0:
+<span style="color: #ddd; position: relative; top: 0.05rem">_</span>
+%elif get('value', 0) < 75:
+▁
+%elif get('value', 0) < 150:
+▂
+%elif get('value', 0) < 300:
+▄
+%elif get('value', 0) < 500:
+▆
+%else:
+█
+%end

--- a/dibs/templates/stats.tpl
+++ b/dibs/templates/stats.tpl
@@ -3,12 +3,14 @@
   %include('common/banner.html')
   <head>
     <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="refresh" content="10">
     %include('common/standard-inclusions.tpl')
 
     <title>DIBS status page</title>
 
     <link rel="stylesheet" href="https://unpkg.com/bootstrap-table@1.18.2/dist/bootstrap-table.min.css">
     <script src="https://unpkg.com/bootstrap-table@1.18.2/dist/bootstrap-table.min.js"></script>
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.0/css/all.css">
   </head>
 
   <body>
@@ -36,7 +38,8 @@
                   <th data-sortable="true" data-sorter="linkedTextSort"
                       data-field="title">&nbsp;<br>&nbsp;<br>Title</th>
 
-                  <th data-sortable="true" data-field="author">&nbsp;<br>&nbsp;<br>Author</th>
+                  <th data-sortable="true"
+                      data-field="author">&nbsp;<br>&nbsp;<br>Author</th>
 
                   <th class="text-center" data-sortable="true"
                       data-field="available">Current<br>active<br>loans</th>
@@ -46,10 +49,15 @@
 
                   <th class="text-center" data-sortable="true" data-field="copies"
                        data-sorter="numberSort">Average<br>loan<br>duration</th>
+
+                  <th class="text-center">
+                    Content<br>retrievals<br>
+                    <span style="letter-spacing: -1px; font-size: 0.9rem">15/30/45/60</span>
+                  </th>
                 </tr>
               </thead>
               <tbody>
-                %for item, current_loans, total_loans, avg_duration in usage_data:
+                %for (item, current_loans, total_loans, avg_duration, retrievals) in usage_data:
                 <tr scope="row" 
                     %if current_loans > 0:
                     class="font-weight-bold"
@@ -81,6 +89,13 @@
 
                   <td>
                     {{avg_duration}}
+                  </td>
+
+                  <td class="text-center text-monospace m-0 p-0" style="letter-spacing: -4px">
+                    %include('common/bar.tpl', value = retrievals[0])
+                    %include('common/bar.tpl', value = retrievals[1])
+                    %include('common/bar.tpl', value = retrievals[2])
+                    %include('common/bar.tpl', value = retrievals[3])
                   </td>
 
                 </tr>                

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ arrow           >= 1.0.3
 boltons         >= 20.2.0
 bottle          >= 0.12.0
 commonpy        >= 1.3.0
+expiringdict    >= 1.2.1
 humanize        >= 0.5.1
 
 # Note: mod_wsgi is only needed by run-server. You can comment it out if you

--- a/tests/test_date_utils.py
+++ b/tests/test_date_utils.py
@@ -1,0 +1,35 @@
+import os
+import pytest
+import sys
+import datetime as dt
+
+
+try:
+    thisdir = os.path.dirname(os.path.abspath(__file__))
+    sys.path.append(os.path.join(thisdir, '..'))
+except:
+    sys.path.append('..')
+
+from dibs.date_utils import *
+
+
+def test_round_minutes():
+    x = dt.datetime(2021, 4, 6, 23, 56, 3, 546899)
+    assert round_minutes(x, 'down') == dt.datetime(2021, 4, 6, 23, 56)
+    assert round_minutes(x, 'up')   == dt.datetime(2021, 4, 6, 23, 57)
+
+    x = dt.datetime(2021, 4, 6, 23, 56, 30, 546899)
+    assert round_minutes(x, 'down') == dt.datetime(2021, 4, 6, 23, 56)
+    assert round_minutes(x, 'up')   == dt.datetime(2021, 4, 6, 23, 57)
+
+    x = dt.datetime(2021, 4, 6, 23, 56, 0, 546899)
+    assert round_minutes(x, 'down') == dt.datetime(2021, 4, 6, 23, 56)
+    assert round_minutes(x, 'up')   == dt.datetime(2021, 4, 6, 23, 57)
+
+    x = dt.datetime(2021, 4, 6, 23, 56, 55, 0)
+    assert round_minutes(x, 'down') == dt.datetime(2021, 4, 6, 23, 56)
+    assert round_minutes(x, 'up')   == dt.datetime(2021, 4, 6, 23, 57)
+
+    x = dt.datetime(2021, 4, 6, 23, 0, 0, 0)
+    assert round_minutes(x, 'down') == dt.datetime(2021, 4, 6, 23, 0)
+    assert round_minutes(x, 'up')   == dt.datetime(2021, 4, 6, 23, 1)


### PR DESCRIPTION
Round loan end times to the next whole minute, and reloan end times down to the whole minute, to avoid the potential confusion that could arise when loans end in the middle of a minute. (Most people probably aren't watching the seconds on their clocks, and our time displays are in whole minutes anyway.)