### PR TITLE
barcodes as strings rather than ints

### DIFF
--- a/dibs/server.py
+++ b/dibs/server.py
@@ -386,7 +386,7 @@ def add_item():
                 max_size = naturalsize(_MAX_THUMBNAIL_SIZE))
 
 
-@dibs.get('/edit/<barcode:int>', apply = VerifyStaffUser())
+@dibs.get('/edit/<barcode>', apply = VerifyStaffUser())
 def edit_item(barcode):
     '''Display the page to add new items.'''
     return page('edit', browser_no_cache = True, action = 'edit',
@@ -407,9 +407,6 @@ def update_item():
     # The HTML form validates the data types, but the POST might come from
     # elsewhere, so we always need to sanity-check the values.
     barcode = request.forms.get('barcode').strip()
-    if not barcode.isdigit():
-        return page('error', summary = 'invalid barcode',
-                    message = f'{barcode} is not a valid barcode')
     duration = request.forms.get('duration').strip()
     if not duration.isdigit() or int(duration) <= 0:
         return page('error', summary = 'invalid duration',
@@ -500,7 +497,7 @@ def update_item():
     redirect(f'{dibs.base_url}/list')
 
 
-@dibs.get('/delete-thumbnail/<barcode:int>', apply = VerifyStaffUser())
+@dibs.get('/delete-thumbnail/<barcode>', apply = VerifyStaffUser())
 def edit(barcode):
     '''Delete the current thumbnail image.'''
     thumbnail_file = join(_THUMBNAILS_DIR, str(barcode) + '.jpg')
@@ -703,7 +700,7 @@ def general_page(name = '/'):
 
 # Next one is used by the item page to update itself w/o reloading whole page.
 
-@dibs.get('/item-status/<barcode:int>', apply = AddPersonArgument())
+@dibs.get('/item-status/<barcode>', apply = AddPersonArgument())
 def item_status(barcode, person):
     '''Returns an item summary status as a JSON string'''
     item, status, explanation, when_available = loan_availability(person.uname, barcode)
@@ -713,7 +710,7 @@ def item_status(barcode, person):
                        'when_available': human_datetime(when_available)})
 
 
-@dibs.get('/item/<barcode:int>', apply = AddPersonArgument())
+@dibs.get('/item/<barcode>', apply = AddPersonArgument())
 def show_item_info(barcode, person):
     '''Display information about the given item.'''
     item, status, explanation, when_available = loan_availability(person.uname, barcode)
@@ -786,7 +783,7 @@ def loan_item(person):
     redirect(f'{dibs.base_url}/view/{barcode}')
 
 
-@dibs.post('/return/<barcode:int>', apply = AddPersonArgument())
+@dibs.post('/return/<barcode>', apply = AddPersonArgument())
 def end_loan(barcode, person):
     '''Handle http post request to return the given item early.'''
 
@@ -825,7 +822,7 @@ def end_loan(barcode, person):
         redirect(f'{dibs.base_url}/item/{barcode}')
 
 
-@dibs.get('/view/<barcode:int>', apply = AddPersonArgument())
+@dibs.get('/view/<barcode>', apply = AddPersonArgument())
 def send_item_to_viewer(barcode, person):
     '''Redirect to the viewer.'''
     item = Item.get(Item.barcode == barcode)
@@ -843,7 +840,7 @@ def send_item_to_viewer(barcode, person):
         redirect(f'{dibs.base_url}/item/{barcode}')
 
 
-@dibs.get('/manifests/<barcode:int>', apply = AddPersonArgument())
+@dibs.get('/manifests/<barcode>', apply = AddPersonArgument())
 def return_iiif_manifest(barcode, person):
     '''Return the manifest file for a given item.'''
     item = Item.get(Item.barcode == barcode)

--- a/dibs/templates/list.tpl
+++ b/dibs/templates/list.tpl
@@ -29,14 +29,15 @@
           <div class="mb-3 table-responsive">
             <table class="table table-borderless"
                    data-page-size="50"
-                   data-toggle="table" data-pagination="true" data-escape="false">
+                   data-toggle="table"
+		   data-search="true"
+		   data-sort-name="barcode"
+		   data-search-align="left" data-pagination="true" data-escape="false">
               <thead class="thead-light align-bottom align-text-bottom">
                 <tr>
-                  <th data-sortable="true" data-sorter="linkedNumberSort"
-                      data-field="barcode">&nbsp;<br>&nbsp;<br>Barcode</th>
+                  <th data-sortable="true" data-field="barcode">&nbsp;<br>&nbsp;<br>Barcode</th>
 
-                  <th data-sortable="true" data-sorter="linkedTextSort"
-                      data-field="title">&nbsp;<br>&nbsp;<br>Title</th>
+                  <th data-sortable="true" data-field="title">&nbsp;<br>&nbsp;<br>Title</th>
 
                   <th data-sortable="true" data-field="author">&nbsp;<br>&nbsp;<br>Author</th>
 
@@ -68,7 +69,8 @@
                   </td>
 
                   <td>
-                    <a href="{{base_url}}/item/{{item.barcode}}">{{item.title}}</a>
+		      <div hidden>{{item.title}}</div>
+                      <a href="{{base_url}}/item/{{item.barcode}}">{{item.title}}</a>
                   </td>
 
                   <td>


### PR DESCRIPTION
As described in #109, if `dibs` encodes barcodes as strings rather than ints, then barcodes with leading zeroes won't make the app throw an error.

Note that retrieving barcodes from the URL and leaving them as strings required us to make some adjustments to the Bootstrap table sorting code in ` dibs/templates/list.tpl`.  

These changes have been working for us in production so far for about two months.